### PR TITLE
Fix usage and update documentation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -58,10 +58,14 @@ import Injection
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        inject {
-            reader
-            database
-            cacheModule
+        do {
+            try inject {
+                reader
+                database
+                cacheModule
+            }
+        } catch {
+            print("TODO: Handle error properly... \(error)")
         }
         return true
     }

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ let cacheModule = module {
 ```swift
 import Injection
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         inject {

--- a/Sources/Injection.swift
+++ b/Sources/Injection.swift
@@ -140,7 +140,7 @@ public enum OptionalInject<T> {
 
 // MARK: Function Builders
 
-@_functionBuilder
+@resultBuilder
 public enum DependenciesBuilder {
     static func buildBlock(_ children: [Dependency]...) -> [Dependency] { children.flatMap { $0 } }
 }

--- a/Sources/Injection.swift
+++ b/Sources/Injection.swift
@@ -142,7 +142,9 @@ public enum OptionalInject<T> {
 
 @resultBuilder
 public enum DependenciesBuilder {
-    static func buildBlock(_ children: [Dependency]...) -> [Dependency] { children.flatMap { $0 } }
+    public static func buildBlock(_ children: [Dependency]...) -> [Dependency] {
+        children.flatMap { $0 }
+    }
 }
 
 /// A new instance of `T` is created each time it is injected. The internal container holds no reference to it.


### PR DESCRIPTION
## Description

The API is not usable because the initializer wasn't accessible.
I also updated the documentation (because the method is throwable), and made other minor improvements.