### PR TITLE
Make lazy singleton explicit

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,12 +11,9 @@ jobs:
     env:
       PACKAGE_NAME: Injection
       
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
-    - uses: fwal/setup-swift@v1
-    - name: Get swift version
-      run: swift --version
     - uses: actions/checkout@v2
     - name: Prepare Build
       run: brew bundle
@@ -27,9 +24,9 @@ jobs:
       run: swiftformat --lint . && swiftlint
     - name: Run tests
       run: swift test --enable-code-coverage
-#    - name: Prepare Code Coverage
-#      run: xcrun llvm-cov export -format="lcov" -instr-profile=$(find .build -name default.profdata) $(find .build -name ${{ env.PACKAGE_NAME }}PackageTests) > info.lcov
-#    - name: Upload to CodeCov.io
-#      uses: codecov/codecov-action@v2
-#      with:
-#        files: ./info.lcov
+    - name: Prepare Code Coverage
+      run: xcrun llvm-cov export -format="lcov" -instr-profile=$(find .build -name default.profdata) $(find .build -name ${{ env.PACKAGE_NAME }}PackageTests) > info.lcov
+    - name: Upload to CodeCov.io
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./info.lcov

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,9 +27,9 @@ jobs:
       run: swiftformat --lint . && swiftlint
     - name: Run tests
       run: swift test --enable-code-coverage
-    - name: Prepare Code Coverage
-      run: xcrun llvm-cov export -format="lcov" -instr-profile=$(find .build -name default.profdata) $(find .build -name ${{ env.PACKAGE_NAME }}PackageTests) > info.lcov
-    - name: Upload to CodeCov.io
-      uses: codecov/codecov-action@v2
-      with:
-        files: ./info.lcov
+#    - name: Prepare Code Coverage
+#      run: xcrun llvm-cov export -format="lcov" -instr-profile=$(find .build -name default.profdata) $(find .build -name ${{ env.PACKAGE_NAME }}PackageTests) > info.lcov
+#    - name: Upload to CodeCov.io
+#      uses: codecov/codecov-action@v2
+#      with:
+#        files: ./info.lcov

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,9 +11,12 @@ jobs:
     env:
       PACKAGE_NAME: Injection
       
-    runs-on: macos-11
+    runs-on: ubuntu-latest
 
     steps:
+    - uses: fwal/setup-swift@v1
+    - name: Get swift version
+      run: swift --version
     - uses: actions/checkout@v2
     - name: Prepare Build
       run: brew bundle

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       PACKAGE_NAME: Injection
       
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       PACKAGE_NAME: Injection
       
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
     - uses: fwal/setup-swift@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,9 +14,6 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: fwal/setup-swift@v1
-    - name: Get swift version
-      run: swift --version
     - uses: actions/checkout@v2
     - name: Prepare Build
       run: brew bundle
@@ -28,6 +25,8 @@ jobs:
     - name: Run tests
       run: swift test --enable-code-coverage
     - name: Prepare Code Coverage
-      run: xcrun llvm-cov export -format="lcov" .build/debug/${{ env.PACKAGE_NAME }}PackageTests.xctest/Contents/MacOS/${{ env.PACKAGE_NAME }}PackageTests -instr-profile .build/debug/codecov/default.profdata > info.lcov
+      run: xcrun llvm-cov export -format="lcov" -instr-profile=$(find .build -name default.profdata) $(find .build -name ${{ env.PACKAGE_NAME }}PackageTests) > info.lcov
     - name: Upload to CodeCov.io
-      run: bash <(curl https://codecov.io/bash)
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./info.lcov

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 `Injection` is a tiny utility to help managing dependency injection.
 
 **Features:**
-- `Singleton`, dependencies that are only instanciated once and are shared amongst its' users
+- `Singleton`, dependencies that are only instanciated once and are shared amongst its users
+- `LazySingleton`, dependencies that are only instanciated once, lazily, and are shared amongst its users
 - `Factory`, dependencies that are instancied upon usage, unique to each user
 - Utility property wrappers
 
@@ -40,8 +41,11 @@ import Injection
 // A dependency that gets created every time it needs to be resolved, and therefore its lifetime is bounded to the instance that uses it
 let reader = factory { RSSReader() }
 
+// A dependency that gets created immediately and is shared throughout the lifetime of the application.
+let database = singleton { Analytics() }
+
 // A dependency that gets created only once, the first time it needs to be resolved and has the lifetime of the application.
-let database = singleton { Realm() }
+let database = lazySingleton { Realm() }
 
 // Syntatic sugar to combine dependencies to inject
 let cacheModule = module {

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 `Injection` is a tiny utility to help managing dependency injection.
 
 **Features:**
-- `Singleton`, dependencies that are only instanciated once and are shared amongst its users
-- `LazySingleton`, dependencies that are only instanciated once, lazily, and are shared amongst its users
+- `Singleton`, dependencies that are only instantiated once and are shared amongst its users
+- `LazySingleton`, dependencies that are only instantiated once, lazily, and are shared amongst its users
 - `Factory`, dependencies that are instancied upon usage, unique to each user
 - Utility property wrappers
 

--- a/Sources/Injection.swift
+++ b/Sources/Injection.swift
@@ -153,13 +153,15 @@ public func factory<T>(constructor: @escaping DependencyFactory<T>) -> [Dependen
     [DependencyContainer(isSingleton: false, factory: constructor)]
 }
 
-/// The same instance of `T` is returned each time it is injected. An instance like this has its lifetime connected to the internal container instance, which essencially is the app lifetime. Since this is gonna be used throughout the app lifetime, it is instantiated immediatly. This allows catching errors early on. There is a lazy version, checkout `lazySingleton`.
+/// The same instance of `T` is returned each time it is injected. An instance like this has its lifetime connected to the internal container instance, which essencially is the app lifetime. Since this is gonna be used throughout the app lifetime, it is instantiated immediately. This allows catching errors early on. 
+/// - SeeAlso: for the lazy equivalent of this function, see `lazySingleton`.
 public func singleton<T>(constructor: @escaping DependencyFactory<T>) rethrows -> [Dependency] {
     let value = try constructor()
     return [DependencyContainer(isSingleton: true, factory: { value })]
 }
 
-/// The same instance of `T` is returned each time it is injected. An instance like this has its lifetime connected to the internal container instance, which essencially is the app lifetime. In this version, the instance is only created the first time it needs to be resolved.
+/// The same instance of `T` is returned each time it is injected. An instance like this has its lifetime connected to the internal container instance, which essentially is the app lifetime. In this version, the instance is only created the first time it needs to be resolved, thus, lazily.
+/// - SeeAlso: for the non-lazy equivalent of this function, see `singleton`.
 public func lazySingleton<T>(constructor: @escaping DependencyFactory<T>) -> [Dependency] {
     return [DependencyContainer(isSingleton: true, factory: constructor)]
 }

--- a/Sources/Injection.swift
+++ b/Sources/Injection.swift
@@ -153,17 +153,21 @@ public func factory<T>(constructor: @escaping DependencyFactory<T>) -> [Dependen
     [DependencyContainer(isSingleton: false, factory: constructor)]
 }
 
-/// The same instance of `T` is returned each time it is injected. An instance like this has its lifetime connected to the internal container instance, which essencially is the app lifetime. Since this is gonna be used throughout the app lifetime, it is instantiated immediately. This allows catching errors early on. 
+/// The same instance of `T` is returned each time it is injected. An instance like this
+/// has its lifetime connected to the internal container instance, which essencially is the app lifetime.
+/// Since this is gonna be used throughout the app lifetime, it is instantiated immediately. This allows catching errors early on.
 /// - SeeAlso: for the lazy equivalent of this function, see `lazySingleton`.
 public func singleton<T>(constructor: @escaping DependencyFactory<T>) rethrows -> [Dependency] {
     let value = try constructor()
     return [DependencyContainer(isSingleton: true, factory: { value })]
 }
 
-/// The same instance of `T` is returned each time it is injected. An instance like this has its lifetime connected to the internal container instance, which essentially is the app lifetime. In this version, the instance is only created the first time it needs to be resolved, thus, lazily.
+/// The same instance of `T` is returned each time it is injected. An instance like this
+/// has its lifetime connected to the internal container instance, which essentially is the app lifetime.
+/// In this version, the instance is only created the first time it needs to be resolved, thus, lazily.
 /// - SeeAlso: for the non-lazy equivalent of this function, see `singleton`.
 public func lazySingleton<T>(constructor: @escaping DependencyFactory<T>) -> [Dependency] {
-    return [DependencyContainer(isSingleton: true, factory: constructor)]
+    [DependencyContainer(isSingleton: true, factory: constructor)]
 }
 
 /// An helper function to create a smaller module of dependencies that can be combined when using the `inject` method.

--- a/Sources/Injection.swift
+++ b/Sources/Injection.swift
@@ -1,9 +1,10 @@
 import Foundation
 
-public typealias DependencyFactory = () -> Any
+public typealias DependencyFactory<T> = () throws -> T
+public typealias AnyDependencyFactory = () throws -> Any
 
 public protocol Dependency {
-    var factory: DependencyFactory { get }
+    var factory: AnyDependencyFactory { get }
     var isSingleton: Bool { get }
     var type: Any.Type { get }
 }
@@ -15,12 +16,12 @@ extension Dependency {
 final class DependencyContainer<T>: Dependency {
     let isSingleton: Bool
     let type: Any.Type
-    let factory: DependencyFactory
+    let factory: AnyDependencyFactory
 
-    init(isSingleton: Bool, factory: @escaping () -> T) {
+    init(isSingleton: Bool, factory: @escaping DependencyFactory<T>) {
         self.isSingleton = isSingleton
         type = T.self
-        self.factory = { factory() }
+        self.factory = { try factory() }
     }
 }
 
@@ -64,14 +65,14 @@ final class Dependencies {
         guard let injectedDependency = injected[typeName] else { throw Error.failedToResolveDependency(typeName) }
         let resolved: T
         if injectedDependency.isSingleton {
-            let buildBlock: () -> T = {
-                let instance = injectedDependency.factory() as! T
+            let buildBlock: DependencyFactory<T> = {
+                let instance = try injectedDependency.factory() as! T
                 self.instances[typeName] = instance
                 return instance
             }
-            resolved = instances[typeName] as? T ?? buildBlock()
+            resolved = try instances[typeName] as? T ?? buildBlock()
         } else {
-            resolved = injectedDependency.factory() as! T
+            resolved = try injectedDependency.factory() as! T
         }
         return resolved
     }
@@ -97,7 +98,7 @@ public struct Inject<T> {
 /// Creates a `Dependency` lazily injectable through `@LazyInject var variableName: Dependency`.
 @propertyWrapper
 public enum LazyInject<T> {
-    case unresolved(() throws -> T)
+    case unresolved(DependencyFactory<T>)
     case resolved(T)
 
     public init() { self = .unresolved { try resolve() } }
@@ -148,13 +149,19 @@ public enum DependenciesBuilder {
 }
 
 /// A new instance of `T` is created each time it is injected. The internal container holds no reference to it.
-public func factory<T>(constructor: @escaping () -> T) -> [Dependency] {
+public func factory<T>(constructor: @escaping DependencyFactory<T>) -> [Dependency] {
     [DependencyContainer(isSingleton: false, factory: constructor)]
 }
 
-/// The same instance of `T` is returned each time it is injected. An instance like this has its lifetime connected to the internal container instance, which essencially is the app lifetime.
-public func singleton<T>(constructor: @escaping () -> T) -> [Dependency] {
-    [DependencyContainer(isSingleton: true, factory: constructor)]
+/// The same instance of `T` is returned each time it is injected. An instance like this has its lifetime connected to the internal container instance, which essencially is the app lifetime. Since this is gonna be used throughout the app lifetime, it is instantiated immediatly. This allows catching errors early on. There is a lazy version, checkout `lazySingleton`.
+public func singleton<T>(constructor: @escaping DependencyFactory<T>) rethrows -> [Dependency] {
+    let value = try constructor()
+    return [DependencyContainer(isSingleton: true, factory: { value })]
+}
+
+/// The same instance of `T` is returned each time it is injected. An instance like this has its lifetime connected to the internal container instance, which essencially is the app lifetime. In this version, the instance is only created the first time it needs to be resolved.
+public func lazySingleton<T>(constructor: @escaping DependencyFactory<T>) -> [Dependency] {
+    return [DependencyContainer(isSingleton: true, factory: constructor)]
 }
 
 /// An helper function to create a smaller module of dependencies that can be combined when using the `inject` method.
@@ -166,6 +173,6 @@ public func module(@DependenciesBuilder makeChildren: () -> [Dependency]) -> [De
 /// app is initialized or at least before any of the injected properties get initialized, otherwise there will be blood.
 ///
 /// - Note: It should be used only once.
-public func inject(@DependenciesBuilder makeDependencies: () -> [Dependency]) throws {
-    try Dependencies.shared.inject(makeDependencies())
+public func inject(@DependenciesBuilder makeDependencies: () throws -> [Dependency]) throws {
+    try Dependencies.shared.inject(try makeDependencies())
 }

--- a/Tests/InjectionTests.swift
+++ b/Tests/InjectionTests.swift
@@ -9,12 +9,12 @@ final class InjectionTests: XCTestCase {
     class A { init(block: Action? = nil) { block?() } }
     class B { init(block: Action? = nil) { block?() } }
     struct C {}
-    
+
     enum Fail: Swift.Error {
         case mock
     }
-    
-    struct Failable {
+
+    enum Failable {
         static func create() throws -> Failable { throw Fail.mock }
     }
 
@@ -231,17 +231,17 @@ final class InjectionTests: XCTestCase {
         XCTAssertNotEqual(ObjectIdentifier(test1.a!), ObjectIdentifier(test2.a!))
         XCTAssertEqual(ObjectIdentifier(test1.b!), ObjectIdentifier(test2.b!))
     }
-    
+
     func test_factoryCreationWithFailure_wontThrowError() {
         XCTAssertNoThrow(try inject { factory { try Failable.create() } })
         assert(try resolve() as Failable, throws: Fail.mock)
     }
-    
+
     func test_lazySingletonCreationWithFailure_wontThrowError() {
         XCTAssertNoThrow(try inject { lazySingleton { try Failable.create() } })
         assert(try resolve() as Failable, throws: Fail.mock)
     }
-    
+
     func test_singletonCreationWithFailure_willThrowErrorImmediately() {
         assert(try inject { try singleton { try Failable.create() } }, throws: Fail.mock)
     }

--- a/Tests/InjectionTests.swift
+++ b/Tests/InjectionTests.swift
@@ -217,7 +217,7 @@ final class InjectionTests: XCTestCase {
         XCTAssertFalse(hasInitializedA)
         XCTAssertNotNil(test1.a)
         XCTAssertTrue(hasInitializedA)
-        XCTAssertTrue(hasInitializedB) // `singleton` is immediatly initialized
+        XCTAssertTrue(hasInitializedB) // `singleton` is immediately initialized
         XCTAssertNotNil(test1.b)
         XCTAssertTrue(hasInitializedB)
         hasInitializedA = false


### PR DESCRIPTION
Previously `singleton` was creating a shared instance but that instance was only created the first time it gets accessed. 

By renaming that option as `lazySingleton` and creating a new `singleton` it makes it explicit in which version the instance is created immediately. 

There are a few advantages of allowing immediate creation, for instance catching errors on creation at the `inject` phase, which ideally is done at the startup of the application. I debated on doing the same for factory, however I only found useful for singletons, which sometimes are third party sdk's that are initialized on app startup.  